### PR TITLE
setting a limit on the number of concurrent renovate branches to 3

### DIFF
--- a/base.json
+++ b/base.json
@@ -13,5 +13,6 @@
   "rebaseWhen": "behind-base-branch",
   "prCreation": "not-pending",
   "branchPrefix": "renovate-",
+  "branchConcurrentLimit": 3,
   "rollbackPrs": true
 }


### PR DESCRIPTION
Renovate by default can have up to 10 concurrent PRs which has resulted in an unacceptably high usage of CircleCI resources as these branches are rebased every time there is a change to main.

This PR sets a default concurrent branch limit of 3 in order to mitigate this issue. This can be overwritten by individual projects if needed. 