### PR TITLE
set minimum age for npm packages

### DIFF
--- a/node.json
+++ b/node.json
@@ -6,6 +6,10 @@
     {
       "matchDepTypes": ["engines"],
       "enabled": false
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
Set minimum age of npm packages (see https://docs.renovatebot.com/configuration-options/#minimumreleaseage)

As well as the associated security benefits, there's stability benefits too:

> npm packages less than 72 hours (3 days) old can be unpublished from the npm registry, which could result in a service impact if you have already updated to it. Set minimumReleaseAge to 3 days for npm packages to prevent relying on a package that can be removed from the registry