### PR TITLE
Remove invalid version range "19-jre-jammy"

### DIFF
--- a/jvm.json
+++ b/jvm.json
@@ -1,11 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ministryofjustice/hmpps-renovate-config:base.json"],
-  "enabledManagers": ["gradle", "gradle-wrapper", "dockerfile", "docker-compose", "helmv3", "helm-values", "github-actions"],
-  "packageRules": [
-    {
-      "matchDatasources": ["docker"],
-      "allowedVersions": "19-jre-jammy"
-    }
-  ]
+  "enabledManagers": ["gradle", "gradle-wrapper", "dockerfile", "docker-compose", "helmv3", "helm-values", "github-actions"]
 }


### PR DESCRIPTION
Fixes the following error:

```
There is an error with this repository's Renovate configuration that needs to be fixed.
As a precaution, Renovate will stop PRs until it is resolved.

Location: config
Error type: Invalid allowedVersions
Message: The following allowedVersions does not parse as a valid version or range: "19-jre-jammy"
```